### PR TITLE
SC-2244: caches name/symbol in the registry

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ Useful for external contracts which need to iterate over the on-chain ilk types 
 
     * `file(bytes32 ilk, bytes32 what, address)`: Update ilk data values
     * `file(bytes32 ilk, bytes32 what, uint256)`: Update ilk data values
+    * `file(bytes32 ilk, bytes32 what, string calldata)`: Update ilk data values
     * `rely(address)` and `deny(address)`: configure `auth` users
     * `removeAuth(bytes32 ilk)`: remove an uncaged ilk adapter
 

--- a/src/IlkRegistry.sol
+++ b/src/IlkRegistry.sol
@@ -82,6 +82,8 @@ contract IlkRegistry {
         address join;  // DSS GemJoin adapter
         address flip;  // Auction contract
         uint256 dec;   // Token decimals
+        string name;   // Token name
+        string symbol; // Token symbol
     }
 
     mapping (bytes32 => Ilk) public ilkData;
@@ -131,7 +133,9 @@ contract IlkRegistry {
             _pip,
             address(join),
             _flip,
-            join.dec()
+            join.dec(),
+            OptionalTokenLike(join.gem()).name(),
+            OptionalTokenLike(join.gem()).symbol()
         );
 
         emit AddIlk(JoinLike(_adapter).ilk());
@@ -165,6 +169,13 @@ contract IlkRegistry {
     function file(bytes32 ilk, bytes32 what, uint256 data) external auth {
         if (what == "dec")       ilkData[ilk].dec  = data;
         else revert("IlkRegistry/file-unrecognized-param-uint256");
+    }
+
+    // Authed edit function
+    function file(bytes32 ilk, bytes32 what, string calldata data) external auth {
+        if (what == "name")        ilkData[ilk].name   = data;
+        else if (what == "symbol") ilkData[ilk].symbol = data;
+        else revert("IlkRegistry/file-unrecognized-param-string");
     }
 
     // Remove ilk from the ilks array by replacing the ilk with the
@@ -214,8 +225,14 @@ contract IlkRegistry {
 
     // Get information about an ilk, including name and symbol
     function info(bytes32 ilk) external view returns (
-        string memory name, string memory symbol, uint256 dec,
-        address gem, address pip, address join, address flip) {
+        string memory name,
+        string memory symbol,
+        uint256 dec,
+        address gem,
+        address pip,
+        address join,
+        address flip
+    ) {
 
         return (this.name(ilk), this.symbol(ilk), this.dec(ilk),
         this.gem(ilk), this.pip(ilk), this.join(ilk), this.flip(ilk));
@@ -253,11 +270,11 @@ contract IlkRegistry {
 
     // Return the symbol of the token, if available
     function symbol(bytes32 ilk) external view returns (string memory) {
-        return OptionalTokenLike(ilkData[ilk].gem).symbol();
+        return ilkData[ilk].symbol;
     }
 
     // Return the name of the token, if available
     function name(bytes32 ilk) external view returns (string memory) {
-        return OptionalTokenLike(ilkData[ilk].gem).name();
+        return ilkData[ilk].name;
     }
 }

--- a/src/IlkRegistry.t.sol
+++ b/src/IlkRegistry.t.sol
@@ -85,6 +85,8 @@ contract IlkRegistryTest is DSTest {
     address constant BAT_JOIN    = 0x3D0B1912B66114d4096F48A8CEe3A56C231772cA;
     address constant BAT_FLIP    = 0xaA745404d55f88C108A28c86abE7b5A1E7817c07;
     uint256 constant BAT_DEC     = 18;
+    string  constant BAT_NAME    = "Basic Attention Token";
+    string  constant BAT_SYMBOL  = "BAT";
 
     bytes32 constant WBTC_A      = bytes32("WBTC-A");
     address constant WBTC_PIP    = 0xf185d0682d50819263941e5f4EacC763CC5C6C42;
@@ -160,13 +162,16 @@ contract IlkRegistryTest is DSTest {
         registry.add(ETH_JOIN);
         registry.add(BAT_JOIN);
         (uint256 pos, address gem, address pip, address join,
-        address flip, uint256 dec) = registry.ilkData(BAT_A);
+        address flip, uint256 dec, string memory name,
+        string memory symbol) = registry.ilkData(BAT_A);
         assertEq(pos, 1); // 0-indexed
         assertEq(gem, BAT_GEM);
         assertEq(pip, BAT_PIP);
         assertEq(join, BAT_JOIN);
         assertEq(flip, BAT_FLIP);
         assertEq(dec, BAT_DEC);
+        assertEq(name, BAT_NAME);
+        assertEq(symbol, BAT_SYMBOL);
     }
 
     function testWards() public {
@@ -343,5 +348,22 @@ contract IlkRegistryTest is DSTest {
     function testFailFileUint256() public {
         registry.add(WBTC_JOIN);
         registry.file(WBTC_A, bytes32("test"), BAT_DEC);
+    }
+
+    function testFileString() public {
+        registry.add(BAT_JOIN);
+        // name
+        assertEq(registry.name(BAT_A), BAT_NAME );
+        registry.file(BAT_A, bytes32("name"), "test");
+        assertEq(registry.name(BAT_A), "test");
+        // symbol
+        assertEq(registry.symbol(BAT_A), BAT_SYMBOL );
+        registry.file(BAT_A, bytes32("symbol"), "TES");
+        assertEq(registry.symbol(BAT_A), "TES");
+    }
+
+    function testFailFileString() public {
+        registry.add(BAT_JOIN);
+        registry.file(BAT_A, bytes32("test"), BAT_NAME);
     }
 }


### PR DESCRIPTION
- adds caches for `name` and `symbol`
- gives `auth` the ability to change those