### PR TITLE
Errorhandling

### DIFF
--- a/src/IlkRegistry.sol
+++ b/src/IlkRegistry.sol
@@ -316,7 +316,7 @@ contract IlkRegistry {
         bytes memory bytesArray = new bytes(32);
         for (uint256 i; i < 32; i++) {
             bytesArray[i] = _bytes32[i];
-            }
+        }
         return string(bytesArray);
     }
 }


### PR DESCRIPTION
* Adds SPDX-License-Identifier
* some cleanup refactoring
* Uses try/catch to get external name and symbol, requires addition of an extra contract
* bump the pragma to `0.6.11` because etherscan is having an issue verifying contracts at `0.6.7`

For certain DSTokens, the `symbol` and `name` are `bytes32` values, which are non-standard. Attempting to call these in-line reverts the transaction, so we add a new contract for managing the calls, then access that with a try/catch block. If the call fails or the name or symbol is empty, the registry will fall back and use the ilk tag, (`ZRX-A`, for example)

An example deployment of this contract is available on kovan at [0x2219ff1fc1f7dd670202950d4f2adf43cabb4b9d](https://kovan.etherscan.io/address/0x2219ff1fc1f7dd670202950d4f2adf43cabb4b9d#code)