### PR TITLE
Refactor to use core contracts rather than storage

### DIFF
--- a/src/IlkRegistry.sol
+++ b/src/IlkRegistry.sol
@@ -98,7 +98,7 @@ contract IlkRegistry {
     mapping (bytes32 => Ilk) public ilkData;
     bytes32[] ilks;
 
-    // Override functions
+    // Override mappings
     mapping (bytes32 => address) private flips;
     mapping (bytes32 => address) private pips;
     mapping (bytes32 => address) private gems;

--- a/src/IlkRegistry.t.sol
+++ b/src/IlkRegistry.t.sol
@@ -83,7 +83,7 @@ contract IlkRegistryTest is DSTest {
     address constant BAT_GEM     = 0x0D8775F648430679A709E98d2b0Cb6250d2887EF;
     address constant BAT_PIP     = 0xB4eb54AF9Cc7882DF0121d26c5b97E802915ABe6;
     address constant BAT_JOIN    = 0x3D0B1912B66114d4096F48A8CEe3A56C231772cA;
-    address constant BAT_FLIP    = 0xaA745404d55f88C108A28c86abE7b5A1E7817c07;
+    address constant BAT_FLIP    = 0x5EdF770FC81E7b8C2c89f71F30f211226a4d7495;
     uint256 constant BAT_DEC     = 18;
     string  constant BAT_NAME    = "Basic Attention Token";
     string  constant BAT_SYMBOL  = "BAT";
@@ -101,7 +101,7 @@ contract IlkRegistryTest is DSTest {
     address constant USDC_GEM    = 0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48;
     address constant USDC_A_PIP  = 0x77b68899b99b686F415d074278a9a16b336085A0;
     address constant USDC_A_JOIN = 0xA191e578a6736167326d05c119CE0c90849E84B7;
-    address constant USDC_A_FLIP = 0xE6ed1d09a19Bd335f051d78D5d22dF3bfF2c28B1;
+    address constant USDC_A_FLIP = 0x545521e0105C5698f75D6b3C3050CfCC62FB0C12;
     uint256 constant USDC_A_DEC  = 6;
 
     bytes32 constant USDC_B      = bytes32("USDC-B");
@@ -161,17 +161,9 @@ contract IlkRegistryTest is DSTest {
     function testIlkData() public {
         registry.add(ETH_JOIN);
         registry.add(BAT_JOIN);
-        (uint256 pos, address gem, address pip, address join,
-        address flip, uint256 dec, string memory name,
-        string memory symbol) = registry.ilkData(BAT_A);
+        (uint256 pos, address join) = registry.ilkData(BAT_A);
         assertEq(pos, 1); // 0-indexed
-        assertEq(gem, BAT_GEM);
-        assertEq(pip, BAT_PIP);
         assertEq(join, BAT_JOIN);
-        assertEq(flip, BAT_FLIP);
-        assertEq(dec, BAT_DEC);
-        assertEq(name, BAT_NAME);
-        assertEq(symbol, BAT_SYMBOL);
     }
 
     function testWards() public {


### PR DESCRIPTION
* Refactor Ilk-Registry to access data from core contracts, while still allowing updatability.

This PR was inspired by a conversation with @gbalabasquer , however I'm not sure that this implementation is more efficient than the existing one.