### PR TITLE
V2: Add reset function to update flip and pip

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,5 @@
-all    :; dapp build
+all    :; SOLC_FLAGS="--optimize --optimize-runs=1000000" dapp --use solc:0.6.7 build --extract
 clean  :; dapp clean
-test   :; dapp test
-deploy :; dapp create IlkRegistry
+test   :; ./test-ilk-registry.sh
+deploy-mainnet :; SOLC_FLAGS="--optimize --optimize-runs=1000000" dapp --use solc:0.6.7 create IlkRegistry 0xaB14d3CE3F733CACB76eC2AbE7d2fcb00c99F3d5
+deploy-kovan :; SOLC_FLAGS="--optimize --optimize-runs=1000000" dapp --use solc:0.6.7 create IlkRegistry 0x24728AcF2E2C403F5d2db4Df6834B8998e56aA5F

--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ Useful for external contracts which need to iterate over the on-chain ilk types 
     * `add(address joinAdapter)`: Add a new ilk to the registry by passing the Join Adapter address. The adapter must be live on mainnet and can not already be included in the registry.
 
     * `remove(bytes32 ilk)`: Remove an ilk from the registry if it's adapter has been caged.
+    * `reset(bytes32 ilk)`: Update the `flip` and `pip` contracts in storage for a given `ilk`.
 
 * Get information from the registry
 

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Useful for external contracts which need to iterate over the on-chain ilk types 
     * `add(address joinAdapter)`: Add a new ilk to the registry by passing the Join Adapter address. The adapter must be live on mainnet and can not already be included in the registry.
 
     * `remove(bytes32 ilk)`: Remove an ilk from the registry if it's adapter has been caged.
-    * `reset(bytes32 ilk)`: Update the `flip` and `pip` contracts in storage for a given `ilk`.
+    * `update(bytes32 ilk)`: Update the `flip` and `pip` contracts in storage for a given `ilk`.
 
 * Get information from the registry
 

--- a/src/IlkRegistry.sol
+++ b/src/IlkRegistry.sol
@@ -52,18 +52,18 @@ interface EndLike {
     function spot()       external view returns (address);
 }
 
-interface OptionalTokenLike {
+interface TokenLike {
     function name()       external view returns (string memory);
     function symbol()     external view returns (string memory);
 }
 
 contract GemInfo {
     function name(address token) external view returns (string memory) {
-        return OptionalTokenLike(token).name();
+        return TokenLike(token).name();
     }
 
     function symbol(address token) external view returns (string memory) {
-        return OptionalTokenLike(token).symbol();
+        return TokenLike(token).symbol();
     }
 }
 

--- a/src/IlkRegistry.sol
+++ b/src/IlkRegistry.sol
@@ -73,7 +73,7 @@ contract IlkRegistry {
     event Deny(address usr);
     event AddIlk(bytes32 ilk);
     event RemoveIlk(bytes32 ilk);
-    event ResetIlk(bytes32 ilk);
+    event UpdateIlk(bytes32 ilk);
     event NameError(bytes32 ilk);
     event SymbolError(bytes32 ilk);
 
@@ -314,7 +314,7 @@ contract IlkRegistry {
     }
 
     // Public function to update an ilk's pip and flip if the ilk has been updated.
-    function reset(bytes32 ilk) external {
+    function update(bytes32 ilk) external {
         require(JoinLike(ilkData[ilk].join).vat() == address(vat), "IlkRegistry/invalid-ilk");
         require(JoinLike(ilkData[ilk].join).live() == 1, "IlkRegistry/ilk-not-live-use-remove-instead");
 
@@ -327,7 +327,7 @@ contract IlkRegistry {
 
         ilkData[ilk].pip   = _pip;
         ilkData[ilk].flip  = _flip;
-        emit ResetIlk(ilk);
+        emit UpdateIlk(ilk);
     }
 
     function bytes32ToStr(bytes32 _bytes32) internal pure returns (string memory) {

--- a/src/IlkRegistry.sol
+++ b/src/IlkRegistry.sol
@@ -86,10 +86,10 @@ contract IlkRegistry {
         _;
     }
 
-    VatLike  public vat;
-    CatLike  public cat;
-    SpotLike public spot;
-    GemInfo  private gemInfo;
+    VatLike  public immutable vat;
+    CatLike  public immutable cat;
+    SpotLike public immutable spot;
+    GemInfo  private immutable gemInfo;
 
     struct Ilk {
         uint256 pos;   // Index in ilks array
@@ -108,19 +108,19 @@ contract IlkRegistry {
     // Pass a dss End contract to the registry to initialize
     constructor(address end) public {
 
-        vat = VatLike(EndLike(end).vat());
-        cat = CatLike(EndLike(end).cat());
-        spot = SpotLike(EndLike(end).spot());
+        VatLike _vat = vat = VatLike(EndLike(end).vat());
+        CatLike _cat = cat = CatLike(EndLike(end).cat());
+        SpotLike _spot = spot = SpotLike(EndLike(end).spot());
 
         gemInfo = new GemInfo();
 
-        require(cat.vat() == address(vat), "IlkRegistry/invalid-cat-vat");
-        require(spot.vat() == address(vat), "IlkRegistry/invalid-spotter-vat");
-        require(vat.wards(address(cat)) == 1, "IlkRegistry/cat-not-authorized");
-        require(vat.wards(address(spot)) == 1, "IlkRegistry/spot-not-authorized");
-        require(vat.live() == 1, "IlkRegistry/vat-not-live");
-        require(cat.live() == 1, "IlkRegistry/cat-not-live");
-        require(spot.live() == 1, "IlkRegistry/spot-not-live");
+        require(_cat.vat() == address(_vat), "IlkRegistry/invalid-cat-vat");
+        require(_spot.vat() == address(_vat), "IlkRegistry/invalid-spotter-vat");
+        require(_vat.wards(address(_cat)) == 1, "IlkRegistry/cat-not-authorized");
+        require(_vat.wards(address(_spot)) == 1, "IlkRegistry/spot-not-authorized");
+        require(_vat.live() == 1, "IlkRegistry/vat-not-live");
+        require(_cat.live() == 1, "IlkRegistry/cat-not-live");
+        require(_spot.live() == 1, "IlkRegistry/spot-not-live");
         wards[msg.sender] = 1;
     }
 

--- a/src/IlkRegistry.sol
+++ b/src/IlkRegistry.sol
@@ -195,9 +195,7 @@ contract IlkRegistry {
     // Authed edit function
     function file(bytes32 ilk, bytes32 what, address data) external auth {
         if (what == "gem")       ilkData[ilk].gem  = data;
-        else if (what == "pip")  ilkData[ilk].pip  = data;
         else if (what == "join") ilkData[ilk].join = data;
-        else if (what == "flip") ilkData[ilk].flip = data;
         else revert("IlkRegistry/file-unrecognized-param-address");
     }
 

--- a/src/IlkRegistry.sol
+++ b/src/IlkRegistry.sol
@@ -267,8 +267,16 @@ contract IlkRegistry {
         address join,
         address flip
     ) {
-        return (this.name(ilk), this.symbol(ilk), this.dec(ilk),
-        this.gem(ilk), this.pip(ilk), this.join(ilk), this.flip(ilk));
+        Ilk memory _ilk = ilkData[ilk];
+        return (
+            _ilk.name,
+            _ilk.symbol,
+            _ilk.dec,
+            _ilk.gem,
+            _ilk.pip,
+            _ilk.join,
+            _ilk.flip
+        );
     }
 
     // The location of the ilk in the ilks array

--- a/src/IlkRegistry.t.sol
+++ b/src/IlkRegistry.t.sol
@@ -83,7 +83,7 @@ contract IlkRegistryTest is DSTest {
     address constant BAT_GEM     = 0x0D8775F648430679A709E98d2b0Cb6250d2887EF;
     address constant BAT_PIP     = 0xB4eb54AF9Cc7882DF0121d26c5b97E802915ABe6;
     address constant BAT_JOIN    = 0x3D0B1912B66114d4096F48A8CEe3A56C231772cA;
-    address constant BAT_FLIP    = 0xaA745404d55f88C108A28c86abE7b5A1E7817c07;
+    address constant BAT_FLIP    = 0x5EdF770FC81E7b8C2c89f71F30f211226a4d7495;
     uint256 constant BAT_DEC     = 18;
     string  constant BAT_NAME    = "Basic Attention Token";
     string  constant BAT_SYMBOL  = "BAT";
@@ -101,7 +101,7 @@ contract IlkRegistryTest is DSTest {
     address constant USDC_GEM    = 0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48;
     address constant USDC_A_PIP  = 0x77b68899b99b686F415d074278a9a16b336085A0;
     address constant USDC_A_JOIN = 0xA191e578a6736167326d05c119CE0c90849E84B7;
-    address constant USDC_A_FLIP = 0xE6ed1d09a19Bd335f051d78D5d22dF3bfF2c28B1;
+    address constant USDC_A_FLIP = 0x545521e0105C5698f75D6b3C3050CfCC62FB0C12;
     uint256 constant USDC_A_DEC  = 6;
 
     bytes32 constant USDC_B      = bytes32("USDC-B");
@@ -353,11 +353,11 @@ contract IlkRegistryTest is DSTest {
     function testFileString() public {
         registry.add(BAT_JOIN);
         // name
-        assertEq(registry.name(BAT_A), BAT_NAME );
+        assertEq(registry.name(BAT_A), BAT_NAME);
         registry.file(BAT_A, bytes32("name"), "test");
         assertEq(registry.name(BAT_A), "test");
         // symbol
-        assertEq(registry.symbol(BAT_A), BAT_SYMBOL );
+        assertEq(registry.symbol(BAT_A), BAT_SYMBOL);
         registry.file(BAT_A, bytes32("symbol"), "TES");
         assertEq(registry.symbol(BAT_A), "TES");
     }
@@ -365,5 +365,25 @@ contract IlkRegistryTest is DSTest {
     function testFailFileString() public {
         registry.add(BAT_JOIN);
         registry.file(BAT_A, bytes32("test"), BAT_NAME);
+    }
+
+    function testReset() public {
+        registry.add(BAT_JOIN);
+        assertEq(registry.pip(BAT_A), BAT_PIP);
+        assertEq(registry.flip(BAT_A), BAT_FLIP);
+        registry.reset(BAT_A);
+        assertEq(registry.pip(BAT_A), BAT_PIP);
+        assertEq(registry.flip(BAT_A), BAT_FLIP);
+    }
+
+    function testResetChanged() public {
+        registry.add(BAT_JOIN);
+        registry.file(BAT_A, bytes32("pip"), USDC_A_PIP);
+        registry.file(BAT_A, bytes32("flip"), USDC_A_FLIP);
+        assertEq(registry.pip(BAT_A), USDC_A_PIP);
+        assertEq(registry.flip(BAT_A), USDC_A_FLIP);
+        registry.reset(BAT_A);
+        assertEq(registry.pip(BAT_A), BAT_PIP);
+        assertEq(registry.flip(BAT_A), BAT_FLIP);
     }
 }

--- a/src/IlkRegistry.t.sol
+++ b/src/IlkRegistry.t.sol
@@ -367,22 +367,22 @@ contract IlkRegistryTest is DSTest {
         registry.file(BAT_A, bytes32("test"), BAT_NAME);
     }
 
-    function testReset() public {
+    function testUpdate() public {
         registry.add(BAT_JOIN);
         assertEq(registry.pip(BAT_A), BAT_PIP);
         assertEq(registry.flip(BAT_A), BAT_FLIP);
-        registry.reset(BAT_A);
+        registry.update(BAT_A);
         assertEq(registry.pip(BAT_A), BAT_PIP);
         assertEq(registry.flip(BAT_A), BAT_FLIP);
     }
 
-    function testResetChanged() public {
+    function testUpdateChanged() public {
         registry.add(BAT_JOIN);
         registry.file(BAT_A, bytes32("pip"), USDC_A_PIP);
         registry.file(BAT_A, bytes32("flip"), USDC_A_FLIP);
         assertEq(registry.pip(BAT_A), USDC_A_PIP);
         assertEq(registry.flip(BAT_A), USDC_A_FLIP);
-        registry.reset(BAT_A);
+        registry.update(BAT_A);
         assertEq(registry.pip(BAT_A), BAT_PIP);
         assertEq(registry.flip(BAT_A), BAT_FLIP);
     }

--- a/src/IlkRegistry.t.sol
+++ b/src/IlkRegistry.t.sol
@@ -30,12 +30,26 @@ interface DSTokenAbstract {
     function balanceOf(address) external view returns (uint256);
 }
 
+interface CatAbstract {
+    function file(bytes32, bytes32, address) external;
+}
+
+interface SpotAbstract {
+    function file(bytes32, bytes32, address) external;
+}
+
 contract CageSpellAction {
     function execute() public {
+
+        // Cage the BAT join adapter for specific test.
         address BAT_JOIN = 0x3D0B1912B66114d4096F48A8CEe3A56C231772cA;
         JoinCageLike joinCage = JoinCageLike(BAT_JOIN);
         // cage it
         joinCage.cage();
+
+        // File the to update the USDC flip and pip for test.
+        CatAbstract(0x78F2c2AF65126834c51822F56Be0d7469D7A523E).file("USDC-A", "flip", 0x5EdF770FC81E7b8C2c89f71F30f211226a4d7495);
+        SpotAbstract(0x65C79fcB50Ca1594B025960e539eD7A9a6D434A3).file("USDC-A", "pip", 0xB4eb54AF9Cc7882DF0121d26c5b97E802915ABe6);
     }
 }
 
@@ -324,13 +338,9 @@ contract IlkRegistryTest is DSTest {
         registry.add(WBTC_JOIN);
         assertEq(registry.pip(WBTC_A), WBTC_PIP);
         registry.file(WBTC_A, bytes32("gem"), address(USDC_GEM));
-        registry.file(WBTC_A, bytes32("pip"), address(USDC_GEM));
         registry.file(WBTC_A, bytes32("join"), address(USDC_GEM));
-        registry.file(WBTC_A, bytes32("flip"), address(USDC_GEM));
         assertEq(registry.gem(WBTC_A), USDC_GEM);
-        assertEq(registry.pip(WBTC_A), USDC_GEM);
         assertEq(registry.join(WBTC_A), USDC_GEM);
-        assertEq(registry.flip(WBTC_A), USDC_GEM);
     }
 
     function testFailFileAddress() public {
@@ -377,13 +387,16 @@ contract IlkRegistryTest is DSTest {
     }
 
     function testUpdateChanged() public {
-        registry.add(BAT_JOIN);
-        registry.file(BAT_A, bytes32("pip"), USDC_A_PIP);
-        registry.file(BAT_A, bytes32("flip"), USDC_A_FLIP);
-        assertEq(registry.pip(BAT_A), USDC_A_PIP);
-        assertEq(registry.flip(BAT_A), USDC_A_FLIP);
-        registry.update(BAT_A);
-        assertEq(registry.pip(BAT_A), BAT_PIP);
-        assertEq(registry.flip(BAT_A), BAT_FLIP);
+        registry.add(USDC_A_JOIN);
+        assertEq(registry.pip(USDC_A), USDC_A_PIP);
+        assertEq(registry.flip(USDC_A), USDC_A_FLIP);
+
+        // Test spell updates to USDC pip and flip to match BAT
+        vote();
+        scheduleWaitAndCast();
+
+        registry.update(USDC_A);
+        assertEq(registry.pip(USDC_A), BAT_PIP);
+        assertEq(registry.flip(USDC_A), BAT_FLIP);
     }
 }

--- a/test-ilk-registry.sh
+++ b/test-ilk-registry.sh
@@ -3,7 +3,7 @@ set -e
 
 [[ "$ETH_RPC_URL" && "$(seth chain)" == "ethlive" ]] || { echo "Please set a mainnet ETH_RPC_URL"; exit 1; }
 
-dapp --use solc:0.6.7 build
+SOLC_FLAGS="--optimize --optimize-runs=1000000" dapp --use solc:0.6.7 build
 
 # MkrAuthority
 export DAPP_TEST_ADDRESS=0x8EE7D9235e01e6B42345120b5d270bdB763624C7


### PR DESCRIPTION
Adds a public function to update `pip` and `flip` for a given ilk type.

Since the addresses are stored in contract storage, they are cheaper to call from this contract vs. reaching out to core contracts. Flips and pips can be updated, however, so this adds a public function that allows a user to call out to the core contracts and update the locally stored variables.

PR set to merge against V2