### PR TITLE
(Optional) Add classcode labels to ilk registry

### DIFF
--- a/src/IlkRegistry.sol
+++ b/src/IlkRegistry.sol
@@ -113,6 +113,8 @@ contract IlkRegistry {
     mapping (bytes32 => Ilk) public ilkData;
     bytes32[] ilks;
 
+    mapping (uint96 => string) public classCodes;
+
     // Initialize the registry
     constructor(address vat_, address dog_, address cat_, address spot_) public {
 
@@ -131,6 +133,9 @@ contract IlkRegistry {
         require(spot.live() == 1,       "IlkRegistry/spot-not-live");
 
         gemInfo = new GemInfo();
+
+        classCodes[1] = "Clipper-type collateral";
+        classCodes[2] = "Flipper-type collateral";
 
         wards[msg.sender] = 1;
     }
@@ -218,6 +223,11 @@ contract IlkRegistry {
     function removeAuth(bytes32 ilk) external auth {
         _remove(ilk);
         emit RemoveIlk(ilk);
+    }
+
+    function addClassCode(uint256 class, string calldata classCode) external auth {
+        require(class <= uint96(-1) && class != 0, "IlkRegistry/invalid-class-code");
+        classCodes[uint96(class)] = classCode;
     }
 
     // Authed edit function

--- a/src/IlkRegistry.t.sol
+++ b/src/IlkRegistry.t.sol
@@ -702,4 +702,15 @@ contract DssIlkRegistryTest is DSTest {
         registry.add(ilks["BAT-A"].join);
         registry.file(ilks["BAT-A"].ilk, bytes32("test"), ilks["BAT-A"].name);
     }
+
+    function testGetClassCode() public {
+        assertEq(registry.classCodes(1), "Clipper-type collateral");
+        assertEq(registry.classCodes(2), "Flipper-type collateral");
+    }
+
+    function testSetClassCode() public {
+        registry.addClassCode(3, "Real world asset collateral");
+
+        assertEq(registry.classCodes(3), "Real world asset collateral");
+    }
 }


### PR DESCRIPTION
Gives governance the ability to add a label for a particular class code.

Might be helpful if many collateral types are added later.